### PR TITLE
updated to pynacl

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,9 +2,13 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
 from cryptography.exceptions import InvalidKey, InvalidTag
-from ed25519 import BadSignatureError
+
+
+from nacl.signing import VerifyKey 
+from nacl.exceptions import BadSignatureError
+
 import argparse
-import ed25519
+#import ed25519
 import base64
 import json
 import sys
@@ -47,14 +51,13 @@ if alg != 'aes-256-gcm+ed25519':
 
 # Verify using Ed25519
 try:
-  verify_key = ed25519.VerifyingKey(
-    os.environ['KEYGEN_PUBLIC_KEY'].encode(),
-    encoding='hex',
+  verify_key = VerifyKey(
+    bytes.fromhex(os.environ['KEYGEN_PUBLIC_KEY'])
   )
 
   verify_key.verify(
-    base64.b64decode(sig),
     ('license/%s' % enc).encode(),
+    base64.b64decode(sig),
   )
 except (AssertionError, BadSignatureError):
   print('[error] verification failed!')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 argparse
 cryptography
-ed25519
+#ed25519
+pynacl


### PR DESCRIPTION
resolves issue https://github.com/keygen-sh/example-python-cryptographic-machine-files/issues/2

and can be synced to the forked repo as well


I changed  the following:

* removed ed25519 from `requirements.txt`
* changed pub key encode to `bytes.fromhex()`  (encode did not work - byte size was not correct)
* https://github.com/Blackstareye/example-python-cryptographic-license-files-fork/blob/59ac35d43ece61cf70dd2e15e993be66b63cb450/main.py#L61-L63
    *  switched message and signature according to migration guide of https://github.com/warner/python-ed25519 and some experimenting


Now it works for me and parses the license key correctly to the enc-json